### PR TITLE
[fix] 修复移动端评论框登录后昵称一栏显示过长的问题

### DIFF
--- a/assert/css/main.css
+++ b/assert/css/main.css
@@ -1017,7 +1017,7 @@ th, td {
         border-right: none;
     }
     #comment-form .comment-inputs {
-        height: 150px;
+        height: auto;
         display: block;
     }
     #comment-form .comment-inputs input {


### PR DESCRIPTION
实际上就是改为自动判断高度。